### PR TITLE
feat: use release resource to install helm charts

### DIFF
--- a/deploy/observability/index.js
+++ b/deploy/observability/index.js
@@ -2,7 +2,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as k8s from '@pulumi/kubernetes';
 import * as config from './src/config.js'
-import { installHelmChart } from './src/chart_install.js';
+import { installHelmRelease } from './src/chart_install.js';
 
 
 const createNamespace = (name) => {
@@ -23,7 +23,7 @@ export default async () => {
     let prometheusHelmChart;
 
     if (config.installPrometheus) {
-        prometheusHelmChart = installHelmChart('prometheus', '25.19.1', namespace, './charts_values/prometheus_values.yaml', 'https://prometheus-community.github.io/helm-charts')
+        prometheusHelmChart = installHelmRelease('prometheus', '25.19.1', namespace, './charts_values/prometheus_values.yaml', 'https://prometheus-community.github.io/helm-charts')
     }
     //
     // TODO: further installed chart processing if required

--- a/deploy/observability/src/chart_install.js
+++ b/deploy/observability/src/chart_install.js
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 
 // use to install Helm Charts
 // TODO: override default values
-export const installHelmChart = (chartName = 'default', chartVersion = 'default', chartNamespace = 'default', chartValuesPath = ' ./default-values.yaml', repoUrl = 'default') => {
+export const installHelmRelease = (chartName = 'default', chartVersion = 'default', chartNamespace = 'default', chartValuesPath = ' ./default-values.yaml', repoUrl = 'default') => {
 
     let values = {};
 
@@ -17,12 +17,12 @@ export const installHelmChart = (chartName = 'default', chartVersion = 'default'
         console.log("Error reading file:", e);
     }
 
-    return new k8s.helm.v3.Chart(chartName, {
+    return new k8s.helm.v3.Release(chartName, {
         chart: chartName,
         version: chartVersion,
         namespace: chartNamespace,
         values: values,
-        fetchOpts: {
+        repositoryOpts: {
             repo: repoUrl,
         },
     });


### PR DESCRIPTION
Install Helm Charts with Release resource instead of Helm Chart Resource.
Helm Chart Release resource supports hooks and is good option to install an unmodified Chart and manage its configuration. 

[Helm Chart Resource vs Helm Release Resource](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/choosing-the-right-helm-resource-for-your-use-case/#choosing-the-right-helm-resource-for-your-use-case)

